### PR TITLE
fix: add scopes to response, all err denied

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -13,14 +13,27 @@ use aws_lambda_events::apigw::{
 
 pub async fn entry(
     event: LambdaEvent<ApiGatewayCustomAuthorizerRequestTypeRequest>
-) -> Result<ApiGatewayCustomAuthorizerResponse<ResponseContext>, Box<dyn Error>> {
+) -> Result<ApiGatewayCustomAuthorizerResponse<ResponseContext>, lambda_runtime::Error> {
+    tracing::debug!("{:?}", event);
+    let res = process(&event).await
+        .map_err(|err| { 
+            tracing::error!("{:?}", err);
+            err 
+        });
+    Ok(ResponseBuilder::default().for_event(event).with_result(res).build())
+}
+
+async fn process(
+    event: &LambdaEvent<ApiGatewayCustomAuthorizerRequestTypeRequest>
+) -> Result<ResponseContext, Box<dyn Error>> {
     let token = event.payload.headers.get("Authorization").ok_or("No authorization header")?.to_str()?;
     let audience = event.payload.path.as_ref().ok_or("No event path")?.to_string();
     let validate = Validate::new_from_env(&audience)?;
     let token = validate.decode(token)?;
     let claims = validate.claims(&token)?;
     let sub = claims.custom.sub().clone().ok_or("Missing sub")?;
-    let res = ResponseContext::from_subject(&sub);
-    ResponseBuilder::default().for_event(event).with_result(res).build()
+    let context = ResponseContext::from_subject(&sub)?
+        .with_scopes(&mut claims.custom.scp().clone().unwrap_or(vec![]));
+    Ok(context)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,11 +6,7 @@
 mod handler;
 mod validate;
 
-use lambda_runtime::{run, service_fn, Error, LambdaEvent};
-use aws_lambda_events::apigw::{
-    ApiGatewayCustomAuthorizerRequestTypeRequest,
-    ApiGatewayCustomAuthorizerResponse
-};
+use lambda_runtime::{run, service_fn, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -19,15 +15,5 @@ async fn main() -> Result<(), Error> {
         .with_target(false)
         .without_time()
         .init();
-    run(service_fn(catch_all)).await
-}
-
-async fn catch_all(
-    event: LambdaEvent<ApiGatewayCustomAuthorizerRequestTypeRequest>
-) -> Result<ApiGatewayCustomAuthorizerResponse<validate::ResponseContext>, Error> {
-    tracing::debug!("{:?}", event);
-    handler::entry(event).await.map_err(|err| {
-        tracing::error!("{:?}", err);
-        Error::from(err.to_string())
-    })
+    run(service_fn(handler::entry)).await
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -75,11 +75,7 @@ impl Validate {
             let iss = token.claims().custom.iss().clone().unwrap();
             if iss != self.issuer { return Err("Invalid iss claim".into()); }
         }
-
-        // TODO fix SCP claim validation.
-        // if token.claims().custom.scp.contains(&"publish".to_string()) {
-        //     return Err("Invalid scp claim".into());
-        // }
+        
         Ok(token.claims().clone())
     }
 }

--- a/src/validate/response_context.rs
+++ b/src/validate/response_context.rs
@@ -8,22 +8,39 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ResponseContext{
-    role: String,
+    namespace: String,
     id: String,
+    scopes: Vec<String>
 }
 
 impl ResponseContext {
-    pub fn new(role: &str, id: &str) -> Self { Self { role: role.to_string(), id: id.to_string() } }
+    
+    pub fn default() -> Self { Self::new("","") }
+    pub fn new(namespace: &str, id: &str) -> Self { 
+        Self { 
+            namespace: namespace.to_string(), 
+            id: id.to_string(),
+            scopes: vec![]
+        } 
+    }
 
-    pub fn role(&self) -> &str { &self.role }
+    pub fn namespace(&self) -> &str { &self.namespace }
     pub fn id(&self) -> &str { &self.id }
-
-    pub fn to_principal(&self) -> String { [self.role.to_string(), self.id.to_string()].join(":") }
+    pub fn scopes(&self) -> &Vec<String> { &self.scopes }
+    
+    pub fn to_principal(&self) -> String { [self.namespace.to_string(), self.id.to_string()].join(":") }
     pub fn from_subject(subject: &str) -> Result<Self, Box<dyn Error>> {
         let mut split = subject.splitn(2, ':');
         Ok(Self {
-            role: split.next().ok_or("Subject missing role")?.to_string(),
-            id: split.next().ok_or("Subject missing id")?.to_string()
+            namespace: split.next().ok_or("Subject missing role")?.to_string(),
+            id: split.next().ok_or("Subject missing id")?.to_string(),
+            scopes: vec![]
         })
+    }
+    pub fn with_scopes(mut self, scopes: &mut Vec<String>) -> Self {
+        let mut scp = self.scopes;
+        scp.append(scopes);
+        self.scopes = scp;
+        self
     }
 }


### PR DESCRIPTION
# Issues Addressed
- Pass scopes downstream to the API service
- Any error thrown is caught and results in a denied policy
